### PR TITLE
Changement du siège social dans les statuts

### DIFF
--- a/reglement.md
+++ b/reglement.md
@@ -2,6 +2,11 @@
 ---
 # Réglement intérieur
 
+## Adresse du siège
+
+Le siège social est situé au 71 Route de Lyon à Illkirch-Graffenstaden (67400).
+
+
 ## Cotisation
 
 Le montant de la cotisation annuelle est fixé à 20 €.

--- a/statuts.md
+++ b/statuts.md
@@ -18,7 +18,7 @@ Pour cela, l’association met notamment à disposition un simulateur à destina
 
 ## Siège
 
-Le siège social est fixé au 122 Avenue Simon dans le 19ème arrondissement de Paris. Il pourra être transféré par simple décision du Bureau.
+Le siège social est situé dans le département du Bas-Rhin. Il pourra être transféré par simple décision du Bureau qui en informera dans les 15 jours l'ensemble des membres de l'association.
 
 
 ## Durée


### PR DESCRIPTION

Je n'ai pas trouvé nécessaire de modifier les statuts pour consolider le caractère d'intérêt général de l'association permettant l'émission de reçu fiscaux. Cela peut être le bon moment mais cela représente une charge de travail supplémentaire. De mon côté, j'avais l'impression que les statuts n'étaient pas forcément blindés de ce côté mais suffisants pour commencer.