### PR TITLE
Changement du siège social dans les statuts

### DIFF
--- a/statuts.md
+++ b/statuts.md
@@ -18,7 +18,7 @@ Pour cela, l’association met notamment à disposition un simulateur à destina
 
 ## Siège
 
-Le siège social est fixé au 122 Avenue Simon dans le 19ème arrondissement de Paris. Il pourra être transféré par simple décision du Bureau.
+Le siège social est situé dans le département des Alpes-Maritimes. Il pourra être transféré par simple décision du Bureau qui en informera dans les 15 jours l'ensemble des membres de l'association.
 
 
 ## Durée


### PR DESCRIPTION
Comme voté en AGX ce jour.

Ayant déménagé en Alsace, mon domicile ne peut pas être le siège d'une association loi 1901. Pour ce faire, il faudrait adapter les statuts au droit local.