### PR TITLE
Explicite la ville du siège de l'association

### DIFF
--- a/statuts.md
+++ b/statuts.md
@@ -18,7 +18,7 @@ Pour cela, l’association met notamment à disposition un simulateur à destina
 
 ## Siège
 
-Le siège social est situé dans le département des Alpes-Maritimes. Il pourra être transféré par simple décision du Bureau qui en informera dans les 15 jours l'ensemble des membres de l'association.
+Le siège social est situé à Nice (Alpes-Maritimes). Il pourra être transféré par simple décision du Bureau qui en informera dans les 15 jours l'ensemble des membres de l'association.
 
 
 ## Durée


### PR DESCRIPTION
Lors de l'AGX du 2/2/21, nous avons modifié l'adresse du siège de l'association. Pour plus de flexibilité en cas de nouveau déménagement, nous n'avions indiqué que le département. En l'état, la demande de modification de l'association envoyée au service de la préfecture responsable de ces demandes a été refusée.

> L'article 3 doit préciser, à minima, la ville où est situé le siège social.

Cette proposition vient corriger ce manquement pour permettre la déclaration en bonne et due forme de la modification de l'association.